### PR TITLE
Fix #5: The unauthenticated git protocol on port 9418 is no longer supported.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "commander": "^4.0.1",
     "nimble": "0.0.2",
     "node-datetime": "^2.1.2",
-    "onvif": "git://github.com/agsh/onvif.git#cc4e57f",
+    "onvif": "https://github.com/agsh/onvif.git#cc4e57f",
     "request-digest": "^1.0.13",
     "xml2js": "^0.4.22"
   },


### PR DESCRIPTION
Replaced `git` protocol by `https` as it is no longer supported